### PR TITLE
Add landing page with security headers

### DIFF
--- a/index.html
+++ b/index.html
@@ -1,0 +1,20 @@
+<!DOCTYPE html>
+<html lang="en">
+  <head>
+    <meta charset="utf-8" />
+    <meta http-equiv="Content-Security-Policy" content="default-src 'self'; img-src 'self' data:;" />
+    <meta name="referrer" content="no-referrer" />
+    <meta name="viewport" content="width=device-width, initial-scale=1" />
+    <title>Pedroskie</title>
+  </head>
+  <body>
+    <main>
+      <h1>Welcome to Pedroskie</h1>
+      <p>This profile site is secured with strict default Content Security Policy and a no-referrer policy.</p>
+      <figure>
+        <img src="data:image/svg+xml,%3Csvg xmlns='http://www.w3.org/2000/svg' viewBox='0 0 120 120'%3E%3Ccircle cx='60' cy='60' r='50' fill='%233498db'/%3E%3Ctext x='60' y='70' font-size='40' text-anchor='middle' fill='%23fff'%3EP%3C/text%3E%3C/svg%3E" alt="Pedroskie logo" width="120" height="120" />
+        <figcaption>An inline SVG rendered via a data URI that aligns with the CSP.</figcaption>
+      </figure>
+    </main>
+  </body>
+</html>


### PR DESCRIPTION
## Summary
- add a simple `index.html` profile landing page
- embed the requested Content Security Policy and referrer policy using meta tags
- include inline SVG logo compliant with the CSP

## Testing
- no automated tests were run (static content only)


------
https://chatgpt.com/codex/tasks/task_e_68d74a1624e88333b371e8e3302bfc0f