### PR TITLE
Add treasury policy security posture brief

### DIFF
--- a/docs/treasury-policy.md
+++ b/docs/treasury-policy.md
@@ -1,0 +1,31 @@
+# Treasury Policy Security Posture Brief
+
+## Configuration Snapshot
+- **Manifest Hash:** `98b9cf34a9ad72d71a52ef5070a021c54e5b63704e8a9325a9f87a2d613bcac0`
+- **Alpha Hash:** `98b9cf34a9ad72d71a52ef5070a021c54e5b63704e8a9325a9f87a2d613bcac0`
+- **Beta Hash:** `98b9cf34a9ad72d71a52ef5070a021c54e5b63704e8a9325a9f87a2d613bcac0`
+- **Gamma Hash:** `98b9cf34a9ad72d71a52ef5070a021c54e5b63704e8a9325a9f87a2d613bcac0`
+- **GPG Thumbprint:** `7A91 F23D 8B34 02E5 C913  A9FD 1F75 D84A 923F 4A9C`
+- **Validate Timestamp:** `2025-10-04T22:05:00Z`
+- **Seal Timestamp:** `2025-10-04T22:10:00Z`
+- **Deploy Timestamp:** `2025-10-04T22:15:00Z`
+- **Verify Timestamp:** `2025-10-04T22:40:00Z`
+
+## Operational Parameters
+- **Hot Wallet Cap:** 20%
+- **Minimum Confirmations:** 6 (Base L2)
+- **Layer-2 Context:** Base network finality assumptions
+
+## Strengths
+- A 2-of-3 Safe multisig establishes resilient governance and limits the impact of individual key compromise on high-value transactions.
+- Limiting the hot wallet exposure to 20% preserves day-to-day liquidity for fees, market making, and routine payouts while reducing the blast radius of custodial breaches.
+- Requiring six Base L2 confirmations strikes a balance between operational throughput and settlement assurance, significantly lowering reorganization risk for inbound flows.
+
+## Observations
+- The alignment of identical manifest, alpha, beta, and gamma hashes simplifies provenance tracking and highlights process consistency across deployment stages.
+- Staged timestamps for validation, sealing, deployment, and verification demonstrate a disciplined release workflow that supports auditability.
+
+## Recommendations
+- Continue periodic key-rotation exercises for the multisig signers to sustain resilience against long-term key exposure.
+- Monitor Base L2 reorg metrics and adjust the confirmation threshold if network conditions change.
+- Maintain real-time monitoring on the hot wallet balance to ensure the cap remains enforceable during volatile market movements.


### PR DESCRIPTION
## Summary
- add a dedicated brief capturing the treasury policy configuration and operational parameters
- document strengths, observations, and recommendations tied to the current hot wallet cap and confirmation settings

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e1d1be0e708333b1ff0684553cdecc