### PR TITLE
Add notarization workflow and manifest tooling

### DIFF
--- a/.github/workflows/notarize-integrity-bundle.yml
+++ b/.github/workflows/notarize-integrity-bundle.yml
@@ -1,0 +1,125 @@
+name: Notarize Integrity Bundle
+
+on:
+  workflow_dispatch:
+  push:
+    tags:
+      - 'v*'
+    branches:
+      - main
+
+permissions:
+  contents: write
+
+jobs:
+  notarize:
+    runs-on: ubuntu-latest
+
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+
+      - name: Install system dependencies
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip jq xxd file
+
+      - name: Install OpenTimestamps client
+        run: |
+          pip3 install --user opentimestamps-client
+
+      - name: Install Foundry (cast)
+        shell: bash
+        run: |
+          curl -L https://foundry.paradigm.xyz | bash
+          echo 'source ~/.foundry/bin/foundryup' >> $GITHUB_ENV
+          source ~/.foundry/bin/foundryup
+          echo "$HOME/.foundry/bin" >> $GITHUB_PATH
+          cast --version
+
+      - name: Generate manifest (hashes, merkle, bundle hash)
+        run: |
+          chmod +x ./gen-manifest.sh
+          ./gen-manifest.sh
+          echo "BUNDLE_HASH=$(sha256sum manifest.txt | awk '{print $1}')" >> $GITHUB_ENV
+
+      - name: Anchor to Bitcoin via OpenTimestamps
+        env:
+          PATH: ${{ env.PATH }}:$HOME/.local/bin
+        run: |
+          ~/.local/bin/ots stamp manifest.txt
+          # Upgrade proof to get a confirmed Bitcoin anchor (may confirm later)
+          ~/.local/bin/ots upgrade manifest.txt.ots || true
+          ~/.local/bin/ots verify manifest.txt || true
+          echo "OTS_PROOF=manifest.txt.ots" >> $GITHUB_ENV
+
+      - name: Anchor to Ethereum (Sepolia) with cast
+        env:
+          RPC_URL: ${{ secrets.SEPOLIA_RPC }}
+          PK: ${{ secrets.ETH_PRIVATE_KEY }}
+        run: |
+          if [ -z "$RPC_URL" ] || [ -z "$PK" ]; then
+            echo "Missing RPC or Private Key secrets. Please set SEPOLIA_RPC and ETH_PRIVATE_KEY."
+            exit 1
+          fi
+          export BUNDLE_HASH=${{ env.BUNDLE_HASH }}
+          # Send a 0-value tx with bundle hash in calldata
+          SEND_OUTPUT=$(cast send --rpc-url "$RPC_URL" --private-key "$PK" --value 0 --data "0x${BUNDLE_HASH}" --legacy || true)
+          echo "$SEND_OUTPUT"
+          # Try to parse tx hash from output
+          ETH_TXID=$(echo "$SEND_OUTPUT" | grep -Eo '0x[a-fA-F0-9]{64}' | head -n1)
+          if [ -z "$ETH_TXID" ]; then
+            echo "Failed to parse Ethereum TxID from cast output."
+            exit 1
+          fi
+          echo "ETH_TXID=$ETH_TXID" >> $GITHUB_ENV
+          # Wait for receipt and capture block number
+          for i in $(seq 1 30); do
+            RECEIPT=$(cast receipt "$ETH_TXID" --rpc-url "$RPC_URL" --json || true)
+            BN=$(echo "$RECEIPT" | jq -r '.blockNumber // empty' | sed 's/^0x//')
+            if [ -n "$BN" ]; then
+              # Convert hex to decimal if needed
+              BN_DEC=$((16#$BN))
+              echo "ETH_BLOCK=$BN_DEC" >> $GITHUB_ENV
+              break
+            fi
+            echo "Waiting for confirmation ($i)..."
+            sleep 6
+          done
+
+      - name: Update manifest with anchors
+        run: |
+          python3 scripts/update-manifest.py \
+            --manifest manifest.txt \
+            --bundle-hash "${{ env.BUNDLE_HASH }}" \
+            --ots-proof "${{ env.OTS_PROOF }}" \
+            --eth-tx "${{ env.ETH_TXID }}" \
+            --eth-block "${{ env.ETH_BLOCK || '' }}"
+
+      - name: Verify anchors
+        env:
+          RPC_URL: ${{ secrets.SEPOLIA_RPC }}
+          PATH: ${{ env.PATH }}:$HOME/.local/bin
+        run: |
+          ~/.local/bin/ots verify manifest.txt || true
+          if [ -n "${{ env.ETH_TXID }}" ]; then
+            cast tx "${{ env.ETH_TXID }}" --rpc-url "$RPC_URL"
+          fi
+
+      - name: Commit notarized artifacts
+        run: |
+          git config user.name "UnityFund CI"
+          git config user.email "ci@unityfund.io"
+          git add manifest.txt manifest.sha256 README-Notarization.txt || true
+          git commit -m "Notarize: update manifest with Bitcoin OTS + Ethereum anchors" || echo "No changes to commit"
+          git push
+
+      - name: Upload artifacts
+        uses: actions/upload-artifact@v4
+        with:
+          name: notarized-bundle
+          path: |
+            manifest.txt
+            manifest.sha256
+            README-Notarization.txt
+            manifest.txt.ots

--- a/docs/treasury-policy.md
+++ b/docs/treasury-policy.md
@@ -1,5 +1,7 @@
 # Treasury Policy Security Posture Brief
 
+This brief outlines the treasury policy's security posture, focusing on the configured hot wallet exposure, confirmation targets, and Base L2 operating context.
+
 ## Configuration Snapshot
 - **Manifest Hash:** `98b9cf34a9ad72d71a52ef5070a021c54e5b63704e8a9325a9f87a2d613bcac0`
 - **Alpha Hash:** `98b9cf34a9ad72d71a52ef5070a021c54e5b63704e8a9325a9f87a2d613bcac0`
@@ -17,9 +19,9 @@
 - **Layer-2 Context:** Base network finality assumptions
 
 ## Strengths
-- A 2-of-3 Safe multisig establishes resilient governance and limits the impact of individual key compromise on high-value transactions.
-- Limiting the hot wallet exposure to 20% preserves day-to-day liquidity for fees, market making, and routine payouts while reducing the blast radius of custodial breaches.
-- Requiring six Base L2 confirmations strikes a balance between operational throughput and settlement assurance, significantly lowering reorganization risk for inbound flows.
+- The 2-of-3 Safe multisig provides robust governance and mitigates any single point of failure for large disbursements.
+- Limiting hot wallet exposure to 20% maintains operational agility for gas, smaller payments, and DEX liquidity while constraining potential loss.
+- Requiring six Base L2 confirmations balances transaction speed with finality guarantees, reducing reorganization risk for inbound flows.
 
 ## Observations
 - The alignment of identical manifest, alpha, beta, and gamma hashes simplifies provenance tracking and highlights process consistency across deployment stages.

--- a/scripts/update-manifest.py
+++ b/scripts/update-manifest.py
@@ -1,0 +1,71 @@
+#!/usr/bin/env python3
+import argparse, re, hashlib, sys, json, os
+from datetime import datetime
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+def replace_once(text, pattern, repl):
+    return re.sub(pattern, repl, text, count=1, flags=re.MULTILINE)
+
+def main():
+    p = argparse.ArgumentParser(description="Update manifest.txt with blockchain anchors and bundle hash")
+    p.add_argument("--manifest", required=True)
+    p.add_argument("--bundle-hash", required=False)
+    p.add_argument("--ots-proof", required=False)
+    p.add_argument("--btc-tx", required=False)
+    p.add_argument("--eth-tx", required=False)
+    p.add_argument("--eth-block", required=False)
+    args = p.parse_args()
+
+    with open(args.manifest, 'r', encoding='utf-8') as f:
+        txt = f.read()
+
+    # Update Bundle-Hash (recompute to be safe if not provided)
+    bundle_hash = args.bundle_hash or sha256_file(args.manifest)
+    txt = re.sub(r"^Bundle-Hash:\s*.*$", f"Bundle-Hash: {bundle_hash}", txt, flags=re.MULTILINE)
+
+    # Update OTS proof and Bitcoin TxID if provided
+    if args.ots_proof:
+        # Insert or replace OTS-Proof-File line
+        txt = re.sub(r"(OTS-Proof-File:\s*).*$", r"\1{}".format(args.ots_proof), txt, flags=re.MULTILINE)
+        # Mark Proof-Status under Bitcoin as Confirmed if btc tx present else Pending
+        status = "Confirmed" if args.btc_tx else "Pending"
+        # Only update the Bitcoin block's Proof-Status (first occurrence after 'Bitcoin-OTS:')
+        txt = re.sub(r"(Bitcoin-OTS:\n(?:.*\n)*?\s*Proof-Status:\s*).*$", r"\1{}".format(status), txt, count=1, flags=re.MULTILINE)
+
+    if args.btc_tx:
+        txt = re.sub(r"(Bitcoin-TxID:\s*).*$", r"\1{}".format(args.btc_tx), txt, flags=re.MULTILINE)
+
+    # Update Ethereum fields
+    if args.eth_tx:
+        txt = re.sub(r"(Ethereum:\n(?:.*\n)*?\s*TxID:\s*).*$", r"\1{}".format(args.eth_tx), txt, count=1, flags=re.MULTILINE)
+        # Also update DataField with bundle-hash
+        txt = re.sub(r"(DataField:\s*)0x\{\{Bundle-Hash\}\}", r"\1" + "0x" + bundle_hash, txt, flags=re.MULTILINE)
+        # Proof status confirmed if block present
+        status = "Confirmed" if args.eth_block else "Pending"
+        txt = re.sub(r"(Ethereum:\n(?:.*\n)*?\s*Proof-Status:\s*).*$", r"\1{}".format(status), txt, count=1, flags=re.MULTILINE)
+    if args.eth_block:
+        txt = re.sub(r"(Block-Number:\s*).*$", r"\1{}".format(args.eth_block), txt, flags=re.MULTILINE)
+
+    with open(args.manifest, 'w', encoding='utf-8') as f:
+        f.write(txt)
+
+    # Touch README-Notarization.txt to reflect latest anchor state (optional no-op here)
+    if os.path.exists("README-Notarization.txt"):
+        # Ensure there's at least a line that references the latest ETH TxID for human readers
+        with open("README-Notarization.txt", 'a', encoding='utf-8') as rf:
+            rf.write(f"\n\n# Auto-Update {datetime.utcnow().isoformat()}Z\n")
+            if args.eth_tx:
+                rf.write(f"Ethereum TxID: {args.eth_tx}\n")
+            if args.ots_proof:
+                rf.write(f"OTS Proof: {args.ots_proof}\n")
+
+    print("✅ manifest.txt updated with anchors.")
+
+if __name__ == "__main__":
+    main()

--- a/scripts/verify_merkle.py
+++ b/scripts/verify_merkle.py
@@ -1,0 +1,30 @@
+#!/usr/bin/env python3
+# Minimal placeholder verifier: recompute bundle hash and list file hashes.
+# Extend to full merkle verification as needed.
+import hashlib, sys, re
+
+def sha256_file(path):
+    h = hashlib.sha256()
+    with open(path, 'rb') as f:
+        for chunk in iter(lambda: f.read(8192), b''):
+            h.update(chunk)
+    return h.hexdigest()
+
+def main():
+    manifest = "manifest.txt" if len(sys.argv) < 2 else sys.argv[1]
+    with open(manifest, 'r', encoding='utf-8') as f:
+        txt = f.read()
+    m = re.search(r"Bundle-Hash:\s*([0-9a-fA-F]{64})", txt)
+    stated = m.group(1) if m else None
+    actual = sha256_file(manifest)
+    print(f"Stated Bundle-Hash: {stated}")
+    print(f"Actual  Bundle-Hash: {actual}")
+    if stated == actual:
+        print("OK: Bundle-Hash matches file content.")
+        sys.exit(0)
+    else:
+        print("MISMATCH: Bundle-Hash differs!")
+        sys.exit(1)
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow to notarize the integrity bundle across Bitcoin and Ethereum anchors
- provide helper scripts for updating manifest anchor metadata and verifying bundle hashes
- refresh the treasury policy brief with an updated strengths overview

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f6fcbbcc8333848c4b7352b8abaf