### PR TITLE
Add CI workflow for dual-chain notarization

### DIFF
--- a/.github/workflows/notarize.yml
+++ b/.github/workflows/notarize.yml
@@ -1,0 +1,91 @@
+name: Notarize Release
+
+on:
+  push:
+    branches:
+      - main
+    tags:
+      - '*'
+  workflow_dispatch:
+
+jobs:
+  notarize:
+    runs-on: ubuntu-latest
+    env:
+      GIT_AUTHOR_NAME: UnityFund CI
+      GIT_AUTHOR_EMAIL: ci@unityfund.io
+      GIT_COMMITTER_NAME: UnityFund CI
+      GIT_COMMITTER_EMAIL: ci@unityfund.io
+    steps:
+      - name: Checkout repository
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+
+      - name: Setup environment
+        run: |
+          sudo apt-get update
+          sudo apt-get install -y python3-pip xxd
+          pip install --quiet opentimestamps-client qrcode[pil]
+          curl -L https://foundry.paradigm.xyz | bash
+          echo "$HOME/.foundry/bin" >> "$GITHUB_PATH"
+
+      - name: Generate manifest
+        run: ./gen-manifest.sh
+
+      - name: Bitcoin timestamp
+        run: |
+          ots stamp manifest.txt
+          ots upgrade manifest.txt.ots || true
+
+      - name: Ethereum anchor
+        env:
+          RPC_URL: ${{ secrets.SEPOLIA_RPC }}
+          PK: ${{ secrets.ETH_PRIVATE_KEY }}
+        run: |
+          if [[ -z "$RPC_URL" || -z "$PK" ]]; then
+            echo "Ethereum secrets are not configured; skipping anchor."
+            exit 0
+          fi
+          BUNDLE_HASH=$(sha256sum manifest.txt | awk '{print $1}')
+          TX_JSON=$(cast send --rpc-url "$RPC_URL" --private-key "$PK" \
+            --value 0 --data "0x${BUNDLE_HASH}")
+          echo "$TX_JSON" > cast-output.json
+          TX_ID=$(echo "$TX_JSON" | grep -o '0x[0-9a-fA-F]*' | head -n1)
+          echo "$TX_ID" > eth_txid.txt
+
+      - name: Update manifest and log
+        run: |
+          OTS_PATH="$(pwd)/manifest.txt.ots"
+          if [[ -f "$OTS_PATH" ]]; then
+            sed -i "s/{{ots_proof}}/${OTS_PATH//\//\/}/" manifest.txt
+          fi
+          if [[ -f eth_txid.txt ]]; then
+            TX_ID=$(cat eth_txid.txt)
+            sed -i "s/{{eth_tx}}/${TX_ID}/" manifest.txt
+            echo "| $(date -u +"%Y-%m-%dT%H:%M:%SZ") | $(git rev-parse --short HEAD) | ${OTS_PATH} | ${TX_ID} |" >> README-Notarization.txt
+          else
+            sed -i "s/{{eth_tx}}/N\\/A/" manifest.txt
+            echo "| $(date -u +"%Y-%m-%dT%H:%M:%SZ") | $(git rev-parse --short HEAD) | ${OTS_PATH} | N\\/A |" >> README-Notarization.txt
+          fi
+
+      - name: Verify proofs
+        if: ${{ secrets.SEPOLIA_RPC != '' && secrets.ETH_PRIVATE_KEY != '' }}
+        env:
+          RPC_URL: ${{ secrets.SEPOLIA_RPC }}
+        run: |
+          ots verify manifest.txt || true
+          if [[ -f eth_txid.txt ]]; then
+            cast tx $(cat eth_txid.txt) --rpc-url "$RPC_URL"
+          fi
+
+      - name: Commit notarization artifacts
+        run: |
+          git status
+          if [[ -n "$(git status --porcelain)" ]]; then
+            git add manifest.txt manifest.txt.ots README-Notarization.txt cast-output.json eth_txid.txt || true
+            git commit -m "Auto-notarized manifest with dual-chain proof"
+            git push
+          else
+            echo "No changes to commit"
+          fi

--- a/README-Notarization.txt
+++ b/README-Notarization.txt
@@ -1,0 +1,6 @@
+# UnityFund Notarization Log
+
+This log records the dual-chain proofs for each notarized release.
+
+| Timestamp (UTC) | Commit | Bitcoin OTS | Ethereum Tx |
+| --- | --- | --- | --- |

--- a/gen-manifest.sh
+++ b/gen-manifest.sh
@@ -1,0 +1,38 @@
+#!/usr/bin/env bash
+set -euo pipefail
+
+MANIFEST_FILE="manifest.txt"
+README_FILE="README-Notarization.txt"
+
+tmp_readme=$(mktemp)
+tmp_treasury=$(mktemp)
+
+sha256sum README.md > "$tmp_readme"
+sha256sum docs/treasury-policy.md > "$tmp_treasury"
+
+{
+  echo "UnityFund Integrity Manifest"
+  echo "Generated: $(date -u +"%Y-%m-%dT%H:%M:%SZ")"
+  echo "Git Commit: $(git rev-parse HEAD)"
+  echo ""
+  echo "Artifacts:"
+  echo "  - README.md sha256: $(cut -d' ' -f1 "$tmp_readme")"
+  echo "  - docs/treasury-policy.md sha256: $(cut -d' ' -f1 "$tmp_treasury")"
+  echo ""
+  echo "Anchors:"
+  echo "  - Bitcoin OTS: {{ots_proof}}"
+  echo "  - Ethereum Tx: {{eth_tx}}"
+} > "$MANIFEST_FILE"
+
+if [[ ! -f "$README_FILE" ]]; then
+  {
+    echo "# UnityFund Notarization Log"
+    echo ""
+    echo "This log records the dual-chain proofs for each notarized release."
+    echo ""
+    echo "| Timestamp (UTC) | Commit | Bitcoin OTS | Ethereum Tx |"
+    echo "| --- | --- | --- | --- |"
+  } > "$README_FILE"
+fi
+
+rm "$tmp_readme" "$tmp_treasury"

--- a/manifest.txt
+++ b/manifest.txt
@@ -1,0 +1,11 @@
+UnityFund Integrity Manifest
+Generated: 2025-10-05T22:53:49Z
+Git Commit: 6214bd1e6725ca2bdeb4ee857769a612875ca81a
+
+Artifacts:
+  - README.md sha256: f5f31b59326666df1a67c554bae8ca49358fd0bff3aa1900431f2b8e29bde2ff
+  - docs/treasury-policy.md sha256: 7e8efbf2dfad2e1fa89c2056b110ebba65f7b0fd40810b40e70e35d5a2110975
+
+Anchors:
+  - Bitcoin OTS: {{ots_proof}}
+  - Ethereum Tx: {{eth_tx}}


### PR DESCRIPTION
## Summary
- add a GitHub Actions workflow that notarizes tagged and main branch builds across Bitcoin and Ethereum
- scaffold a manifest generator script and notarization log for the pipeline to update
- check in an initial manifest template that is populated by the automated job

## Testing
- not run

------
https://chatgpt.com/codex/tasks/task_e_68e2f6b5854c83338e41e931f6134984