### PR TITLE
Add FlowMesh v2 heartbeat and predictor tools

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,2 @@
+__pycache__/
+*.pyc

--- a/README.md
+++ b/README.md
@@ -34,3 +34,15 @@ If the OTS verification is successful, the release is 💚 STILL VERIFIED and gu
 Pedroskie/Pedroskie is a ✨ special ✨ repository because its `README.md` (this file) appears on your GitHub profile.
 You can click the Preview link to take a look at your changes.
 --->
+
+## FlowMesh v2 (Technical Mode)
+
+A minimal heartbeat + prediction loop for the phone (sensor), Pi (orchestrator),
+and laptop (witness):
+
+- `python -m flowmesh.heartbeat <node>` emits a heartbeat snapshot into
+  `flowmesh/flowmesh_bus.json`.
+- `python -m flowmesh.predictor` runs forward-risk scoring across recent
+  snapshots to surface drift and failure signals.
+
+See `docs/flowmesh_v2.md` for the mesh bus schema and design notes.

--- a/docs/flowmesh_v2.md
+++ b/docs/flowmesh_v2.md
@@ -1,0 +1,80 @@
+# FlowMesh v2 (Technical Mode)
+
+FlowMesh v2 is a lightweight mesh health plane that links the phone (sensor),
+the Raspberry Pi (orchestrator), and the laptop (witness) into a shared
+observability loop. It focuses on heartbeat propagation, shared state on disk,
+predictive health scoring, and mesh-wide situational awareness.
+
+## Components
+
+- **flowmesh/flowmesh_bus.json** — Shared state file (heartbeat, metrics,
+  node scores, and mesh summary). If it is missing, the heartbeat daemon
+  auto-creates a default bus with `phone`, `pi`, and `laptop` nodes.
+- **flowmesh/heartbeat.py** — Emits heartbeats and metrics. Updates node
+  status, health score, and the mesh summary.
+- **flowmesh/predictor.py** — Runs a small risk model that surfaces forward
+  failure probability signals for each node.
+
+## Using the heartbeat emitter
+
+```bash
+python -m flowmesh.heartbeat phone \
+  --latency-ms 28 --packet-loss 0.02 --cpu-percent 23 --battery-percent 82
+```
+
+The command will update `flowmesh/flowmesh_bus.json` with the latest snapshot,
+re-score the node, and recompute the mesh summary.
+
+## Running the prediction pass
+
+```bash
+python -m flowmesh.predictor
+```
+
+This consumes the shared bus, runs a trend-based risk model across recent
+snapshots, and writes the predicted risk to each node entry.
+
+## Bus schema (compact)
+
+```json
+{
+  "mesh_id": "flowmesh-v2",
+  "updated_at": "2024-05-22T10:03:08.254Z",
+  "nodes": {
+    "phone": {
+      "role": "sensor",
+      "heartbeat": "2024-05-22T10:03:08.254Z",
+      "status": "online",
+      "metrics": {"latency_ms": 28.0, "packet_loss": 0.02},
+      "health_score": 0.93,
+      "predicted_risk": 0.14,
+      "history": [ {"latency_ms": 28.0, "packet_loss": 0.02, ...} ]
+    }
+  },
+  "mesh_summary": {
+    "online": 2,
+    "degraded": 1,
+    "offline": 0,
+    "average_health": 0.82,
+    "last_prediction": "2024-05-22T10:03:08.254Z"
+  }
+}
+```
+
+## Design notes
+
+- **Shared heartbeat files** live under `flowmesh/flowmesh_bus.json`.
+- **Node-to-node health scoring** runs inside `heartbeat.py` with a weighted
+  heuristic that combines latency, packet loss, CPU, thermal, and battery.
+- **Distributed prediction** is provided by `predictor.py` using a moving
+  window of recent snapshots.
+- **Mesh-wide telemetry** is encoded in `mesh_summary` to power dashboards or
+  other collectors.
+- **Cross-node awareness** comes from the shared bus and the average-health
+  rollup.
+- **Failure forecasting** uses latency slope, packet loss, low battery, and
+  thermal risk signals.
+- **Distributed logs** can consume the `history` list per node for audit and
+  replay.
+- **Mesh consensus** can layer on top of the shared bus by having guardians
+  vote on the `mesh_summary` or future `mesh_decisions` fields.

--- a/flowmesh/__init__.py
+++ b/flowmesh/__init__.py
@@ -1,0 +1,1 @@
+"""FlowMesh v2 utilities for heartbeat, prediction, and mesh telemetry."""

--- a/flowmesh/bus.py
+++ b/flowmesh/bus.py
@@ -1,0 +1,139 @@
+from __future__ import annotations
+
+import json
+from dataclasses import dataclass, field
+from datetime import datetime, timezone
+from pathlib import Path
+from typing import Dict, List, Optional
+
+ISO_FORMAT = "%Y-%m-%dT%H:%M:%S.%fZ"
+
+
+def _utc_now() -> str:
+    return datetime.now(timezone.utc).strftime(ISO_FORMAT)
+
+
+def _default_node(role: str) -> "NodeState":
+    return NodeState(role=role)
+
+
+@dataclass
+class MetricSnapshot:
+    latency_ms: Optional[float] = None
+    packet_loss: Optional[float] = None
+    cpu_percent: Optional[float] = None
+    battery_percent: Optional[float] = None
+    temperature_c: Optional[float] = None
+    free_memory_mb: Optional[float] = None
+    note: Optional[str] = None
+    timestamp: str = field(default_factory=_utc_now)
+
+
+@dataclass
+class NodeState:
+    role: str
+    heartbeat: Optional[str] = None
+    status: str = "unknown"
+    metrics: Dict[str, float] = field(default_factory=dict)
+    health_score: Optional[float] = None
+    predicted_risk: Optional[float] = None
+    history: List[MetricSnapshot] = field(default_factory=list)
+
+    def add_snapshot(self, snapshot: MetricSnapshot) -> None:
+        self.history.append(snapshot)
+        self.heartbeat = snapshot.timestamp
+        self.metrics = {
+            k: v
+            for k, v in snapshot.__dict__.items()
+            if k != "timestamp" and v is not None
+        }
+
+
+@dataclass
+class MeshSummary:
+    online: int = 0
+    degraded: int = 0
+    offline: int = 0
+    average_health: Optional[float] = None
+    last_prediction: Optional[str] = None
+
+
+@dataclass
+class MeshBus:
+    mesh_id: str
+    updated_at: Optional[str] = None
+    nodes: Dict[str, NodeState] = field(default_factory=dict)
+    mesh_summary: MeshSummary = field(default_factory=MeshSummary)
+
+    def touch(self) -> None:
+        self.updated_at = _utc_now()
+
+
+class BusCodec:
+    @staticmethod
+    def load(path: Path) -> MeshBus:
+        if not path.exists():
+            raise FileNotFoundError(f"Bus file not found: {path}")
+
+        with path.open("r", encoding="utf-8") as handle:
+            raw = json.load(handle)
+
+        nodes = {
+            name: NodeState(
+                role=node.get("role", "unknown"),
+                heartbeat=node.get("heartbeat"),
+                status=node.get("status", "unknown"),
+                metrics=node.get("metrics", {}),
+                health_score=node.get("health_score"),
+                predicted_risk=node.get("predicted_risk"),
+                history=[MetricSnapshot(**snapshot) for snapshot in node.get("history", [])],
+            )
+            for name, node in raw.get("nodes", {}).items()
+        }
+
+        mesh_summary = MeshSummary(**raw.get("mesh_summary", {}))
+
+        return MeshBus(
+            mesh_id=raw.get("mesh_id", "flowmesh-v2"),
+            updated_at=raw.get("updated_at"),
+            nodes=nodes,
+            mesh_summary=mesh_summary,
+        )
+
+    @staticmethod
+    def save(bus: MeshBus, path: Path) -> None:
+        serializable = {
+            "mesh_id": bus.mesh_id,
+            "updated_at": bus.updated_at,
+            "nodes": {
+                name: {
+                    "role": node.role,
+                    "heartbeat": node.heartbeat,
+                    "status": node.status,
+                    "metrics": node.metrics,
+                    "health_score": node.health_score,
+                    "predicted_risk": node.predicted_risk,
+                    "history": [snapshot.__dict__ for snapshot in node.history[-50:]],
+                }
+                for name, node in bus.nodes.items()
+            },
+            "mesh_summary": bus.mesh_summary.__dict__,
+        }
+
+        with path.open("w", encoding="utf-8") as handle:
+            json.dump(serializable, handle, indent=2)
+
+
+def ensure_bus(path: Path) -> MeshBus:
+    if path.exists():
+        return BusCodec.load(path)
+
+    bus = MeshBus(mesh_id="flowmesh-v2")
+    bus.nodes = {
+        "phone": _default_node("sensor"),
+        "pi": _default_node("orchestrator"),
+        "laptop": _default_node("witness"),
+    }
+    bus.touch()
+    BusCodec.save(bus, path)
+    return bus

--- a/flowmesh/flowmesh_bus.json
+++ b/flowmesh/flowmesh_bus.json
@@ -1,0 +1,40 @@
+{
+  "mesh_id": "flowmesh-v2",
+  "updated_at": null,
+  "nodes": {
+    "phone": {
+      "role": "sensor",
+      "heartbeat": null,
+      "status": "unknown",
+      "metrics": {},
+      "health_score": null,
+      "predicted_risk": null,
+      "history": []
+    },
+    "pi": {
+      "role": "orchestrator",
+      "heartbeat": null,
+      "status": "unknown",
+      "metrics": {},
+      "health_score": null,
+      "predicted_risk": null,
+      "history": []
+    },
+    "laptop": {
+      "role": "witness",
+      "heartbeat": null,
+      "status": "unknown",
+      "metrics": {},
+      "health_score": null,
+      "predicted_risk": null,
+      "history": []
+    }
+  },
+  "mesh_summary": {
+    "online": 0,
+    "degraded": 0,
+    "offline": 0,
+    "average_health": null,
+    "last_prediction": null
+  }
+}

--- a/flowmesh/heartbeat.py
+++ b/flowmesh/heartbeat.py
@@ -1,0 +1,110 @@
+from __future__ import annotations
+
+import argparse
+from pathlib import Path
+from typing import Dict, Optional
+
+from .bus import BusCodec, MeshBus, MetricSnapshot, ensure_bus
+
+
+def calculate_status(snapshot: MetricSnapshot) -> str:
+    if snapshot.packet_loss is not None and snapshot.packet_loss > 0.2:
+        return "offline"
+    if snapshot.latency_ms is not None and snapshot.latency_ms > 300:
+        return "degraded"
+    if snapshot.cpu_percent is not None and snapshot.cpu_percent > 95:
+        return "degraded"
+    return "online"
+
+
+def update_mesh_summary(bus: MeshBus) -> None:
+    online = 0
+    degraded = 0
+    offline = 0
+    health_values = []
+
+    for node in bus.nodes.values():
+        if node.status == "online":
+            online += 1
+        elif node.status == "degraded":
+            degraded += 1
+        else:
+            offline += 1
+
+        if node.health_score is not None:
+            health_values.append(node.health_score)
+
+    bus.mesh_summary.online = online
+    bus.mesh_summary.degraded = degraded
+    bus.mesh_summary.offline = offline
+    bus.mesh_summary.average_health = (
+        sum(health_values) / len(health_values) if health_values else None
+    )
+
+
+def health_score(snapshot: MetricSnapshot) -> float:
+    score = 1.0
+    if snapshot.latency_ms:
+        score -= min(snapshot.latency_ms / 1000, 0.5)
+    if snapshot.packet_loss:
+        score -= min(snapshot.packet_loss, 0.5)
+    if snapshot.cpu_percent and snapshot.cpu_percent > 80:
+        score -= min((snapshot.cpu_percent - 80) / 100, 0.2)
+    if snapshot.battery_percent is not None and snapshot.battery_percent < 20:
+        score -= 0.2
+    if snapshot.temperature_c and snapshot.temperature_c > 70:
+        score -= 0.1
+    return max(0.0, round(score, 3))
+
+
+def apply_heartbeat(bus_path: Path, node_name: str, metrics: Dict[str, float], note: Optional[str]) -> MeshBus:
+    bus = ensure_bus(bus_path)
+    node = bus.nodes.get(node_name)
+    if node is None:
+        from .bus import _default_node  # local import to avoid circular import in type checking
+
+        node = _default_node(role="unknown")
+        bus.nodes[node_name] = node
+
+    snapshot = MetricSnapshot(**metrics, note=note)
+    node.add_snapshot(snapshot)
+    node.status = calculate_status(snapshot)
+    node.health_score = health_score(snapshot)
+    bus.touch()
+    update_mesh_summary(bus)
+    BusCodec.save(bus, bus_path)
+    return bus
+
+
+def parse_args() -> argparse.Namespace:
+    parser = argparse.ArgumentParser(description="FlowMesh heartbeat emitter")
+    parser.add_argument("node", help="Node name (e.g. phone, pi, laptop)")
+    parser.add_argument("--bus", default="flowmesh/flowmesh_bus.json", help="Path to the bus JSON")
+    parser.add_argument("--latency-ms", type=float, dest="latency_ms")
+    parser.add_argument("--packet-loss", type=float, dest="packet_loss")
+    parser.add_argument("--cpu-percent", type=float, dest="cpu_percent")
+    parser.add_argument("--battery-percent", type=float, dest="battery_percent")
+    parser.add_argument("--temperature-c", type=float, dest="temperature_c")
+    parser.add_argument("--free-memory-mb", type=float, dest="free_memory_mb")
+    parser.add_argument("--note")
+    return parser.parse_args()
+
+
+def main() -> None:
+    args = parse_args()
+    bus_path = Path(args.bus)
+
+    metrics = {
+        "latency_ms": args.latency_ms,
+        "packet_loss": args.packet_loss,
+        "cpu_percent": args.cpu_percent,
+        "battery_percent": args.battery_percent,
+        "temperature_c": args.temperature_c,
+        "free_memory_mb": args.free_memory_mb,
+    }
+
+    apply_heartbeat(bus_path=bus_path, node_name=args.node, metrics=metrics, note=args.note)
+
+
+if __name__ == "__main__":
+    main()

--- a/flowmesh/predictor.py
+++ b/flowmesh/predictor.py
@@ -1,0 +1,112 @@
+from __future__ import annotations
+
+from dataclasses import dataclass
+from pathlib import Path
+from statistics import mean
+from typing import Dict, List
+
+from .bus import BusCodec, MeshBus, MetricSnapshot, NodeState, ensure_bus
+
+
+@dataclass
+class Prediction:
+    node: str
+    risk: float
+    signal: str
+
+
+class RiskModel:
+    def __init__(self, history_window: int = 5) -> None:
+        self.history_window = history_window
+
+    def predict(self, node: NodeState) -> Prediction:
+        recent = node.history[-self.history_window :]
+        if not recent:
+            return Prediction(node=node.role, risk=0.1, signal="insufficient data")
+
+        latency_score = self._latency_score(recent)
+        loss_score = self._loss_score(recent)
+        battery_score = self._battery_score(recent)
+        thermal_score = self._thermal_score(recent)
+
+        risk = min(1.0, latency_score + loss_score + battery_score + thermal_score)
+        signal = ", ".join(
+            part
+            for part in [
+                self._signal("latency", latency_score),
+                self._signal("loss", loss_score),
+                self._signal("battery", battery_score),
+                self._signal("thermal", thermal_score),
+            ]
+            if part
+        )
+        return Prediction(node=node.role, risk=round(risk, 3), signal=signal or "stable")
+
+    def _latency_score(self, recent: List[MetricSnapshot]) -> float:
+        values = [snap.latency_ms for snap in recent if snap.latency_ms is not None]
+        if not values:
+            return 0.05
+        slope = self._slope(values)
+        base = mean(values) / 1000
+        return min(0.5, base + max(0.0, slope * 0.1))
+
+    def _loss_score(self, recent: List[MetricSnapshot]) -> float:
+        values = [snap.packet_loss for snap in recent if snap.packet_loss is not None]
+        if not values:
+            return 0.05
+        return min(0.5, mean(values))
+
+    def _battery_score(self, recent: List[MetricSnapshot]) -> float:
+        values = [snap.battery_percent for snap in recent if snap.battery_percent is not None]
+        if not values:
+            return 0.0
+        low_battery = 1 - min(values) / 100
+        return max(0.0, low_battery * 0.3)
+
+    def _thermal_score(self, recent: List[MetricSnapshot]) -> float:
+        values = [snap.temperature_c for snap in recent if snap.temperature_c is not None]
+        if not values:
+            return 0.0
+        overheat = [max(0.0, (v - 60) / 100) for v in values]
+        return min(0.2, mean(overheat))
+
+    def _slope(self, values: List[float]) -> float:
+        if len(values) < 2:
+            return 0.0
+        x = list(range(len(values)))
+        x_mean = mean(x)
+        y_mean = mean(values)
+        numerator = sum((xi - x_mean) * (yi - y_mean) for xi, yi in zip(x, values))
+        denominator = sum((xi - x_mean) ** 2 for xi in x) or 1
+        return numerator / denominator
+
+    def _signal(self, name: str, score: float) -> str:
+        if score > 0.4:
+            return f"{name}:high"
+        if score > 0.2:
+            return f"{name}:medium"
+        return ""
+
+
+def update_predictions(bus_path: Path, model: RiskModel | None = None) -> Dict[str, Prediction]:
+    bus = ensure_bus(bus_path)
+    model = model or RiskModel()
+    predictions: Dict[str, Prediction] = {}
+
+    for node_name, state in bus.nodes.items():
+        prediction = model.predict(state)
+        state.predicted_risk = prediction.risk
+        predictions[node_name] = prediction
+
+    bus.mesh_summary.last_prediction = bus.updated_at
+    BusCodec.save(bus, bus_path)
+    return predictions
+
+
+def main() -> None:
+    bus_path = Path("flowmesh/flowmesh_bus.json")
+    update_predictions(bus_path)
+
+
+if __name__ == "__main__":
+    main()


### PR DESCRIPTION
## Summary
- add the FlowMesh package with a shared bus codec, heartbeat emitter, and risk prediction model
- seed a shared bus JSON alongside documentation and README guidance for FlowMesh v2
- ignore Python cache artifacts to keep the repository clean

## Testing
- `python -m flowmesh.heartbeat phone --bus /tmp/flowmesh_test.json --latency-ms 30 --packet-loss 0.02 --cpu-percent 20 --battery-percent 90`
- `python -m flowmesh.predictor`
- `python - <<'PY'
from pathlib import Path
from flowmesh.heartbeat import apply_heartbeat
from flowmesh.predictor import update_predictions

bus_path = Path("/tmp/flowmesh_test.json")
apply_heartbeat(bus_path, "pi", {"latency_ms": 120, "packet_loss": 0.15}, note="validation")
predictions = update_predictions(bus_path)
print({k: (v.risk, v.signal) for k, v in predictions.items()})
PY`


------
[Codex Task](https://chatgpt.com/codex/tasks/task_e_6920c182c33c8333a6eb98da48d66cfe)